### PR TITLE
Fix typo

### DIFF
--- a/index-pt-BR.md
+++ b/index-pt-BR.md
@@ -97,7 +97,7 @@ As reclamações são especialmente impactantes quando são escritas por um cida
 
 - Email: [international@accc.gov.au](mailto:international@accc.gov.au?cc=australia@keepandroidopen.org)
 - Faça uma reclamação junto à [Australian Competition and Consumer Commission (ACCC)](https://www.accc.gov.au/about-us/contact-us-or-report-an-issue)
-- Envie um pedido à Australian Australian Consumers’ Association ([CHOICE](https://accounts.choice.com.au/contact-us/)). Peça para que eles apresentem uma reclamação designada à Australian Competition & Consumer Comission (ACCC).
+- Envie um pedido à Australian Consumers’ Association ([CHOICE](https://accounts.choice.com.au/contact-us/)). Peça para que eles apresentem uma reclamação designada à Australian Competition & Consumer Comission (ACCC).
 
 #### Japão
 

--- a/index-tr.md
+++ b/index-tr.md
@@ -95,7 +95,7 @@ Tüm dünyada düzenleyici kurumlar hakikaten teknoloji sektöründeki tekeller 
 #### Avustralya
 - E-posta: [international@accc.gov.au](mailto:international@accc.gov.au?cc=australia@keepandroidopen.org)
 - [Australian Competition and Consumer Commission (ACCC)](https://www.accc.gov.au/about-us/contact-us-or-report-an-issue) kurumuna şikayette bulunun.
-- Avustralyalı Tüketiciler Derneği'ne (Australian Australian Consumers’ Association) ([CHOICE](https://accounts.choice.com.au/contact-us/)) talebinizi iletin. Onlardan Avustralya Rekabet ve Tüketici Komisyonu'na (Australian Competition & Consumer Comission (ACCC)) belirli bir şikayette bulunmalarını isteyin.
+- Avustralyalı Tüketiciler Derneği'ne (Australian Consumers’ Association) ([CHOICE](https://accounts.choice.com.au/contact-us/)) talebinizi iletin. Onlardan Avustralya Rekabet ve Tüketici Komisyonu'na (Australian Competition & Consumer Comission (ACCC)) belirli bir şikayette bulunmalarını isteyin.
 
 #### Japonya
 - E-posta: [intnldiv@jftc.go.jp](mailto:intnldiv@jftc.go.jp?cc=japan@keepandroidopen.org)

--- a/index.md
+++ b/index.md
@@ -96,7 +96,7 @@ Complaints are especially impactful when they are authored by a citizen of that 
 
 - Email: [international@accc.gov.au](mailto:international@accc.gov.au?cc=australia@keepandroidopen.org)
 - File a report with the [Australian Competition and Consumer Commission (ACCC)](https://www.accc.gov.au/about-us/contact-us-or-report-an-issue)
-- Send a request to Australian Australian Consumers’ Association ([CHOICE](https://accounts.choice.com.au/contact-us/)). Ask them to lodge a designated complaint to the Australian Competition & Consumer Comission (ACCC).
+- Send a request to Australian Consumers’ Association ([CHOICE](https://accounts.choice.com.au/contact-us/)). Ask them to lodge a designated complaint to the Australian Competition & Consumer Comission (ACCC).
 
 #### Japan
 


### PR DESCRIPTION
Fixes probably a typo ("Australian Consumers’ Association" instead of "Australian Australian Consumers’ Association").