### PR TITLE
Add a link to the Slovak page to the language list

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -118,7 +118,8 @@
       <a href="/de/">Deutsch</a> |
       <a href="/es/">Español</a> |
       <a href="/pt-BR/">Português</a> |
-      <a href="/cs/">Česky</a> |
+      <a href="/cs/">Čeština</a> |
+      <a href="/sk/">Slovenčina</a> |
       <a href="/tr/">Türkçe</a> |
       <a href="/zh-TW/">正體中文</a> |
       <a href="/uk/">Українська</a>


### PR DESCRIPTION
Adds a link to the Slovak page to the language lists. It also adapts the link linking to the Czech version.