### PR TITLE
Added Thai translation & ETDA link & TCC link

### DIFF
--- a/src/content/pages/en/index.md
+++ b/src/content/pages/en/index.md
@@ -85,6 +85,10 @@ Complaints are especially impactful when they are authored by a citizen of that 
 
 - Email: [saraban@tcct.or.th](mailto:saraban@tcct.or.th?cc=thailand@keepandroidopen.org)
 - Contact the [Office of Trade Competition Commission (OTCC)](https://www.tcct.or.th/)
+- Email: [info@etda.or.th](mailto:info@etda.or.th?cc=thailand@keepandroidopen.org)
+- Contact the [Electronic Transactions Development Agency (ETDA)](https://www.etda.or.th/en/contact/contact.aspx)
+- Email: [contact@tcc.or.th](mailto:contact@tcc.or.th?cc=thailand@keepandroidopen.org)
+- Contact the [Thailand Consumers Council (TCC)](https://www.tcc.or.th/)
 - _Note: Thailand is slated to be one of the [initial 4 countries](https://www.theregister.com/2025/08/26/android_developer_verification_sideloading/) where developer registration will be enforced_
 
 #### Indonesia

--- a/src/content/pages/th/index.md
+++ b/src/content/pages/th/index.md
@@ -1,0 +1,307 @@
+---
+title: "อย่าปิดกั้น Android"
+lang: th
+description: "การรณรงค์เพื่อให้Android ยังเปิดกว้างสำหรับทุกคนในการพัฒนาแอป"
+
+# localizable sections for the footer text
+contact_header: "ติดต่อ"
+contact_email: "อีเมล"
+site_problems_header: "ปัญหา"
+site_report_issues: "รายงานปัญหาเกี่ยวกับเว็บไซต์"
+site_disclaimer: "**ข้อจำกัดความรับผิดชอบ:** เว็บไซต์นี้เป็นโครงการที่ดำเนินการโดยชุมชนไม่แสวงหาผลกำไร เปิดดำเนินการเพื่อให้ข้อมูลและให้ความรู้เท่านั้น"
+site_privacy: "**ความเป็นส่วนตัว:** เว็บไซต์นี้ไม่ใช้คุกกี้และไม่มีการติดตามหรือบันทึกข้อมูลผู้ใช้งาน"
+site_copyright: "**ลิขสิทธิ์:** ไม่มี"
+
+lockdown_banner: "Androidจะเป็นแพลตฟอร์มที่ถูกล็อก"
+open_letter_header: "จดหมายเปิดผนึก"
+open_letter_description: "จดหมายเปิดผนึกเพื่อสนับสนุนให้Androidยังเป็นแพลตฟอร์มที่เปิดกว้าง"
+---
+
+ในเดือนสิงหาคม ปี 2025 Google [ประกาศ](https://developer.android.com/developer-verification) ว่าตั้งแต่เดือนกันยายน ปี 2026 เป็นต้นไป
+จะไม่สามารถพัฒนาแอปพลิเคชันสำหรับแพลตฟอร์มAndroidได้อีกต่อไป
+หากไม่ลงทะเบียนกับ Google ก่อน
+การลงทะเบียนนี้จะรวมถึง:
+
+- การจ่ายเงินให้กับ Google
+{:.li-list .li-money}
+- การยอมรับข้อกำหนดและเงื่อนไขของ Google
+{:.li-list .li-terms}
+- การให้ข้อมูลเพื่อระบุตัวตนจากรัฐบาล
+{:.li-list .li-id}
+- การอัปโหลดหลักฐานของprivate keyของนักพัฒนา
+{:.li-list .li-signing}
+- การแสดงรายชื่อแอปพลิเคชันทั้งหมดที่มีอยู่ในปัจจุบันและในอนาคต
+{:.li-list .li-appids}
+
+## สิ่งนี้หมายถึงสิทธิของคุณอย่างไร
+
+➤ คุณ **ผู้บริโภค**, ซื้อเครื่องAndroidโดยเชื่อในคำมั่นสัญญาของ Google ว่าเป็นแพลตฟอร์มการประมวลผลแบบเปิดกว้าง คุณสามารถเลือกรันซอฟต์แวร์ใดก็ได้ที่คุณต้องการ แต่ว่า ตั้งแต่เดือนกันยายน ปี 2026 เป็นต้นไป พวกเขาจะผลักดันการอัปเดตระบบปฏิบัติการของคุณโดยไม่ขออนุญาต ซึ่งจะบล็อกสิทธินี้อย่างถาวร และปล่อยให้เขาเป็นผู้ตัดสินใจว่าซอฟต์แวร์ไหนที่คุณได้รับอนุญาตให้เชื่อถือได้
+
+➤ คุณ **ผู้สร้างสรรค์**, จะไม่สามารถพัฒนาแอปพลิเคชันและแบ่งปันกับเพื่อน ครอบครัว และชุมชนของคุณโดยตรงได้อีกต่อไป โดยไม่ต้องขออนุมัติจาก Google ก่อน คำมั่นสัญญาของAndroid — และข้อได้เปรียบที่ใช้ในการตลาดเพื่อแยกตัวออกจากไอโฟน — คือการเปิดกว้างเสมอมา แต่ดูเหมือน Google จะรู้สึกว่าพวกเขาสามารถควบคุมระบบนิเวศ(รวมทั้งกฏต่างๆ)ของAndroidอย่างแน่นหนา เพียงพอที่จะสามารถละทิ้งหลักการนี้ได้
+
+➤ คุณ **รัฐบาล**, กำลังสละสิทธิของประชาชนและอธิปไตยด้านดิจิทัลของคุณเองให้กับบริษัทที่มีประวัติในการปฏิบัติตามคำขอที่ไม่ชอบทางกฎหมายของระบอบเผด็จการเพื่อลบแอปพลิเคชันที่ถูกต้องตามกฎหมายที่พวกเขาไม่ชอบใจ ซอฟต์แวร์ที่สำคัญต่อการดำเนินงานของธุรกิจและรัฐบาลของคุณจะอยู่ภายใต้ความปราณีที่ไม่โปร่งใสของบริษัทที่อยู่ห่างไกลและไม่มีความรับผิดชอบ
+
+## คุณสามารถช่วยเหลือได้อย่างไรบ้าง
+
+### ผู้บริโภค: ติดต่อหน่วยงานกำกับดูแลระดับชาติ {#consumers}
+
+หน่วยงานกำกับดูแลทั่วโลกมีความกังวลอย่างมาก เกี่ยวกับการผูกขาดและการรวมศูนย์อำนาจในภาคเทคโนโลยี และต้องการฟังโดยตรงจากบุคคลที่ได้รับผลกระทบและความกังวล เมื่อติดต่อหน่วยงานกำกับดูแลโดยตรง คุณควร _สุภาพ_ และ _เฉพาะเจาะจง_ เกี่ยวกับความเสียหายที่คุณเชื่อว่านโยบายเหล่านี้จะก่อให้เกิดทั้งต่อผู้บริโภคและต่อการแข่งขัน
+
+คำร้องเรียนมีผลกระทบมากเป็นพิเศษเมื่อเขียนโดยพลเมืองของประเทศหรือภูมิภาคนั้น และเมื่อภาษาของอีเมลเขียนเป็นหนึ่งในภาษาทางการของหน่วยงานปกครองในภูมิภาคนั้น ขอ _การรับทราบเป็นลายลักษณ์อักษร_ ของคำร้องเรียน และพิจารณาส่งต่อคำตอบใด ๆ ที่คุณได้รับไปยัง [victory@keepandroidopen.org](mailto:victory@keepandroidopen.org) เพื่อให้เราอาจมา highlight และอ้างอิง
+
+#### สหภาพยุโรป
+- อีเมลทีม Digital Markets Act: [EC-DMA@ec.europa.eu](mailto:EC-DMA@ec.europa.eu?cc=dma@keepandroidopen.org)
+- ติดต่อทีม DMA: [https://digital-markets-act.ec.europa.eu/contact-dma-team_en](https://digital-markets-act.ec.europa.eu/contact-dma-team_en)
+- ~~ส่งความคิดเห็นเกี่ยวกับการประสานงานระหว่าง DMA และ GDPR ของสหภาพยุโรป: [การปรึกษาหารือเกี่ยวกับแนวทางร่วมเกี่ยวกับการประสานงานระหว่าง DMA และ GDPR](https://digital-markets-act.ec.europa.eu/consultation-joint-guidelines-interplay-between-dma-and-gdpr_en) จนถึงวันที่ 4 ธันวาคม~~
+- อีเมลต่อต้านการผูกขาด: [COMP-GREFFE-ANTITRUST@ec.europa.eu](mailto:COMP-GREFFE-ANTITRUST@ec.europa.eu?cc=europe@keepandroidopen.org)
+- ร้องเรียนต่อ [นโยบายการแข่งขันของสหภาพยุโรป](https://competition-policy.ec.europa.eu/antitrust-and-cartels/contact_en)
+- ~~[หมดอายุแล้ว] ส่งความคิดเห็นเกี่ยวกับกฎหมายความยุติธรรมด้านดิจิทัลของสหภาพยุโรป: [กฎหมายความยุติธรรมด้านดิจิทัลของสหภาพยุโรป: แสดงความคิดเห็นของคุณ](https://ec.europa.eu/info/law/better-regulation/have-your-say/initiatives/14622-Digital-Fairness-Act_en)~~
+
+#### สหราชอาณาจักร
+
+- อีเมล: [general.enquiries@cma.gov.uk](mailto:general.enquiries@cma.gov.uk?cc=uk@keepandroidopen.org)
+- แจ้งเบาะแสต่อ [หน่วยงานการแข่งขันและการตลาดของสหราชอาณาจักร](https://contact-the-cma.service.gov.uk/wizard/classify)
+
+#### สหรัฐอเมริกา
+
+- แจ้งเบาะแสต่อ [กระทรวงยุติธรรมสหรัฐอเมริกา แบบฟอร์มรายงานต่อต้านการผูกขาดออนไลน์](https://www.justice.gov/atr/webform/submit-your-antitrust-report-online)
+- ยื่นคำร้องต่อ [คณะกรรมาธิการการค้าแห่งสหพันธรัฐสหรัฐอเมริกา: คำร้องต่อต้านการผูกขาด](https://www.ftc.gov/advice-guidance/competition-guidance/antitrust-complaint-intake)
+- ~~อีเมล (ไม่ใช้งานแล้ว): [antitrust@ftc.gov](mailto:antitrust@ftc.gov?cc=usftc@keepandroidopen.org)~~
+- ~~อีเมล (ไม่ใช้งานแล้ว): [antitrust.complaints@usdoj.gov](mailto:antitrust.complaints@usdoj.gov?cc=usdoj@keepandroidopen.org)~~
+
+#### บราซิล
+
+- อีเมล: [superintendencia@cade.gov.br](mailto:superintendencia@cade.gov.br?cc=brazil@keepandroidopen.org)
+- ติดต่อ Procon (ขึ้นอยู่กับรัฐของคุณ) และ [Senacon](https://www.gov.br/mj/pt-br/assuntos/seus-direitos/consumidor)
+- _หมายเหตุ: บราซิลเป็นหนึ่งใน [4 ประเทศแรก](https://www.theregister.com/2025/08/26/android_developer_verification_sideloading/) ที่จะมีการบังคับใช้การลงทะเบียนนักพัฒนา_
+
+#### สิงคโปร์
+
+- อีเมล: [cccs_feedback@cccs.gov.sg](mailto:cccs_feedback@cccs.gov.sg?cc=singapore@keepandroidopen.org)
+- ติดต่อ [คณะกรรมการการแข่งขันและผู้บริโภคแห่งสิงคโปร์ (CCCS)](https://www.cccs.gov.sg)
+- _หมายเหตุ: สิงคโปร์เป็นหนึ่งใน [4 ประเทศแรก](https://www.theregister.com/2025/08/26/android_developer_verification_sideloading/) ที่จะมีการบังคับใช้การลงทะเบียนนักพัฒนา_
+
+#### ประเทศไทย
+
+- อีเมล: [saraban@tcct.or.th](mailto:saraban@tcct.or.th?cc=thailand@keepandroidopen.org)
+- ติดต่อ [สำนักงานคณะกรรมการการแข่งขันทางการค้า (OTCC)](https://www.tcct.or.th/)
+- อีเมล: [info@etda.or.th](mailto:info@etda.or.th?cc=thailand@keepandroidopen.org)
+- ติดต่อ [สำนักงานพัฒนาธุรกรรมทางอิเล็กทรอนิคส์ (ETDA)](https://www.etda.or.th/en/contact/contact.aspx)
+- อีเมล: [contact@tcc.or.th](mailto:contact@tcc.or.th?cc=thailand@keepandroidopen.org)
+- ติดต่อ [สำนักงานคุ้มครองผู้บริโภค (TCC)](https://www.tcc.or.th/)
+- _หมายเหตุ: ประเทศไทยเป็นหนึ่งใน [4 ประเทศแรก](https://www.theregister.com/2025/08/26/android_developer_verification_sideloading/) ที่จะมีการบังคับใช้การลงทะเบียนนักพัฒนา_
+
+#### อินโดนีเซีย
+
+- อีเมล: [infokom@kppu.go.id](mailto:infokom@kppu.go.id?cc=indonesia@keepandroidopen.org)
+- ติดต่อ [KPPU สำหรับคำร้องเรียนด้านการแข่งขัน](https://eng.kppu.go.id)
+- _หมายเหตุ: อินโดนีเซียเป็นหนึ่งใน [4 ประเทศแรก](https://www.theregister.com/2025/08/26/android_developer_verification_sideloading/) ที่จะมีการบังคับใช้การลงทะเบียนนักพัฒนา_
+
+#### สวิตเซอร์แลนด์
+
+- ยื่นรายงานต่อ [คณะกรรมการการแข่งขัน](https://www.weko.admin.ch/weko/en/home/kontakt/kontakt.html)
+
+#### ออสเตรเลีย
+
+- อีเมล: [international@accc.gov.au](mailto:international@accc.gov.au?cc=australia@keepandroidopen.org)
+- ยื่นรายงานต่อ [คณะกรรมการการแข่งขันและผู้บริโภคแห่งออสเตรเลีย (ACCC)](https://www.accc.gov.au/about-us/contact-us-or-report-an-issue)
+- ส่งคำขอไปยังสมาคมผู้บริโภคชาวออสเตรเลีย ([CHOICE](https://accounts.choice.com.au/contact-us/)) ขอให้พวกเขาแจ้งคำร้องเรียนที่กำหนดต่อคณะกรรมการการแข่งขันและผู้บริโภคแห่งออสเตรเลีย (ACCC)
+- ติดต่อสมาชิกสภาผู้แทนราษฎรหรือวุฒิสมาชิกของรัฐของคุณ หากคุณไม่ทราบเขตเลือกตั้งของคุณ คุณสามารถหาได้ [ที่นี่](https://electorate.aec.gov.au/) และคุณสามารถค้นหาสมาชิกสภาผู้แทนราษฎรหรือวุฒิสมาชิกของคุณได้ [ที่นี่](https://www.aph.gov.au/Senators_and_Members/Parliamentarian_Search_Results)
+
+#### ญี่ปุ่น
+
+- อีเมล: [intnldiv@jftc.go.jp](mailto:intnldiv@jftc.go.jp?cc=japan@keepandroidopen.org)
+- ติดต่อ [คณะกรรมการการค้าที่ยุติธรรมของญี่ปุ่น (JFTC)](https://www.jftc.go.jp/)
+
+#### เกาหลีใต้
+
+- อีเมล: [kftc@korea.kr](mailto:kftc@korea.kr?cc=korea@keepandroidopen.org)
+- ติดต่อ [คณะกรรมการการค้าที่ยุติธรรมของเกาหลี (KFTC)](https://www.ftc.go.kr/)
+
+#### อินเดีย
+
+- อีเมล: [cci‑chairman@nic.in](mailto:cci‑chairman@nic.in?cc=india@keepandroidopen.org)
+- ติดต่อ [คณะกรรมการการแข่งขันของอินเดีย (CCI)](https://www.cci.gov.in/)
+
+#### แคนาดา
+
+- อีเมล: [info@competitionbureau.gc.ca](mailto:info@competitionbureau.gc.ca?cc=canada@keepandroidopen.org)
+- ยื่นคำร้องต่อ [สำนักงานคณะกรรมการการแข่งขันแคนาดา](https://competition-bureau.canada.ca/en/contact-competition-bureau-canada/complaint-form)
+- ยื่นรายงานต่อ [https://competition-bureau.canada.ca/en](https://competition-bureau.canada.ca/en/contact-competition-bureau-canada/complaint-form)
+
+#### ไต้หวัน
+
+- อีเมล: [ftc@ftc.gov.tw](mailto:ftc@ftc.gov.tw?cc=taiwan@keepandroidopen.org)
+- ติดต่อ [คณะกรรมการการค้าที่ยุติธรรม (FTC)](https://www.ftc.gov.tw/)
+
+#### ตุรกี
+
+- ติดต่อ [Rekabet Kurumu / หน่วยงานการแข่งขันของตุรกี (RK)](https://edevlet.rekabet.gov.tr/Talep/Anasayfa)
+
+#### อาร์เจนตินา
+
+- อีเมล: [cndc@produccion.gob.ar](mailto:cndc@produccion.gob.ar?cc=argentina@keepandroidopen.org)
+- ติดต่อ [Comisión Nacional de Defensa de la Competencia (CNDC)](https://www.argentina.gob.ar/defensadelacompetencia)
+
+#### เม็กซิโก
+
+- อีเมล: [denuncias@antimonopolio.gob.mx](mailto:denuncias@antimonopolio.gob.mx?cc=mexico@keepandroidopen.org)
+- ติดต่อ [Comisión Nacional Antimonopolio](https://www.antimonopolio.gob.mx/Micrositios/)
+
+#### ฟิลิปปินส์
+
+- ติดต่อ [คณะกรรมการการแข่งขันแห่งฟิลิปปินส์ (PCC)](https://www.phcc.gov.ph/)
+
+#### โปแลนด์
+* อีเมล: [uokik@uokik.gov.pl](mailto:uokik@uokik.gov.pl?cc=poland@keepandroidopen.org)
+* ติดต่อ [สำนักงานปกป้องการแข่งขันและผู้บริโภค (Urząd Ochrony Konkurencji i Konsumentów - UOKiK)](https://uokik.gov.pl/)
+
+
+#### สาธารณรัฐเช็ก
+
+* อีเมล: [posta@uohs.gov.cz](mailto:posta@uohs.gov.cz?cc=czechia@keepandroidopen.org)
+* ติดต่อ [สำนักงานคุ้มครองการแข่งขันทางเศรษฐกิจ (Úřad pro ochranu hospodářské soutěže – ÚOHS)](https://www.uohs.gov.cz/en/)
+
+
+#### ยูเครน
+
+- ติดต่อ [คณะกรรมการแห่งชาติสำหรับการกำกับดูแลการสื่อสารทางอิเล็กทรอนิกส์ของรัฐ](https://nkek.gov.ua/)
+- ติดต่อ [กระทรวงการเปลี่ยนแปลงดิจิทัล](https://thedigital.gov.ua/)
+- ติดต่อ [คณะกรรมการต่อต้านผูกขาดแห่งยูเครน](https://amcu.gov.ua/)
+
+
+
+### นักพัฒนา: ต่อต้านและปฏิเสธ
+
+หากคุณเป็นนักพัฒนาแอปพลิเคชัน _**อย่าสมัคร**_ สำหรับโปรแกรมการเข้าถึงก่อนใคร ทำการตรวจสอบตัวตน หรือยอมรับคำเชิญไปยัง Android Developer Console ตอบกลับ (อย่างสุภาพ) ต่อคำเชิญใด ๆ ด้วยรายการข้อกังวลและข้อคัดค้านของคุณ
+
+—— _แผนการยึดครองของพวกเขาจะสามารถประสบความสำเร็จได้ หากนักพัฒนายอมรับมัน_ ——
+
+ไม่สนับสนุนให้เหล่านักพัฒนา แอพ และองค์กร สมัครเข้าสู่โปรแกรมเหล่านั้น ใช้บอร์ดสาธารณะ โซเชี่ยลมีเดีย และ บล๊อคโพสต์ ในการกระจายข่าว ใส่ [FreeDroidWarn library](https://github.com/woheller69/FreeDroidWarn) ในโค้ดของคุณ เพื่อให้ผู้ใช้แอพของคุณรับรู้
+
+If you are a Google employee or contractor of good conscience and have additional insight about the program, including planned technical implementation details or additional rationales for the program, please reach out to [tips@keepandroidopen.org](mailto:tips@keepandroidopen.org) from a _non-work_ machine and a _non-gmail_ account. Your information will be kept in strict confidence.
+
+### ทุกคน: ทำให้เสียงของคุณดังขึ้น
+
+- [ติดตั้ง F-Droid](https://f-droid.org) บนอุปกรณ์Androidของคุณ ยิ่งมีผู้คนมากขึ้นที่ใช้ตลาดแอปพลิเคชันทางเลือก มันก็ยิ่งยากขึ้นที่จะปิดกั้นพวกเขา
+- ให้ความคิดเห็นโดยตรงแก่ Google โดยใช้แบบสำรวจ [ข้อกำหนดการตรวจสอบตัวตนของนักพัฒนาAndroid](https://docs.google.com/forms/d/e/1FAIpQLSfN3UQeNspQsZCO2ITkdzMxv81rJDEGGjO-UIDDY28Rz_GEVA/viewform?pli=1)
+- ทำให้เสียงของคุณดังขึ้นบนโซเชียลมีเดียและเขียนโพส และลิงก์ไปยัง <https://keepandroidopen.org>
+- ต่อสู้กับ astroturfing: เมื่อคุณพบโพสต์ที่น่าสงสัยบนฟอรั่มชุมชนและโซเชียลมีเดียที่สนับสนุนานโยบาย ("เอ่อ จริงๆแล้วนะ...") ให้ท้าทายพวกเขาและอย่าอาย
+- ช่วยโครงการนี้โดย [แก้ไขหน้านี้](https://github.com/keepandroidopen/keepandroidopen.github.io/blob/main/index.md) ด้วยข้อมูลที่เป็นประโยชน์เพิ่มเติม
+- [ลงชื่อใน petitition change.org นี้](https://www.change.org/p/stop-google-from-limiting-apk-file-usage?recruiter=1370041382&recruited_by_id=fddec6e0-0e30-11f0-a55d-cd0eb0fd0ac4)
+
+#### ติดต่อองค์กรสิทธิผู้บริโภค/สิทธิดิจิทัลเหล่านี้
+
+- [Euroconsumers](https://www.euroconsumers.org/)
+- [Electronic Frontier Foundation](https://www.eff.org/)
+- [Digital Rights Ireland](https://www.digitalrights.ie/)
+- [Digital Freedom and Rights Association (Sweden)](https://www.dfri.se/)
+- [European Digital Rights](https://edri.org/)
+- [La Quadrature du Net (France)](https://www.laquadrature.net/)
+- [April (France)](https://www.april.org/en)
+- [Free Software Foundation](https://www.fsf.org/)
+- [Free Software Foundation Europe](https://fsfe.org/)
+- [Free Software Movement India](https://www.fsmi.in/)
+- [IT-Political Association of Denmark](https://www.itpol.dk/)
+- [Digital Rights Watch (Australia)](https://digitalrightswatch.org.au/)
+- [Open Rights Group (UK)](https://www.openrightsgroup.org/)
+- [Bits of Freedom (Netherlands)](https://www.bitsoffreedom.nl/)
+- [Swecha Andhra Pradesh](https://www.swechaap.org/)
+
+#### สนับสนุนโครงการเหล่านี้
+
+โครงการเหล่านี้กำลังทำงานเพื่อจัดหาการแข่งขันที่จำเป็นมากในพื้นที่ฮาร์ดแวร์มือถือ
+
+- [Librephone by the Free Software Foundation](https://librephone.fsf.org/)
+- [PinePhone by Pine64](https://pine64.org/devices/pinephone/)
+- [Spirit Smartphone by V3lectronics](https://github.com/V3lectronics/SPIRIT)
+- [Shiftphone](https://www.shift.eco/en/)
+- [PureOS by Purism](https://pureos.net/)
+- [PostmarketOS](https://postmarketos.org/)
+- [Replicant](https://www.replicant.us/)
+- [Ubuntu Touch by the UBPorts Community](https://www.ubuntu-touch.io/)
+- [Fairphone](https://www.fairphone.com/)
+- [Sailfish OS](https://sailfishos.org/)
+- [Mobian](https://mobian-project.org/)
+- [LineageOS](https://lineageos.org/)
+- [/e/OS](https://e.foundation/e-os/)
+
+## อ้างอิง
+
+### ภาพรวม
+
+- [https://consumerrights.wiki/w/Android_Developer_Verification](https://consumerrights.wiki/w/Android_Developer_Verification)
+
+### บรรณาธิการและบล็อก
+
+- "Your Smartphone, Their Rules: How App Stores Enable Corporate-Government Censorship" - [https://www.aclu.org/news/free-speech/app-store-oligopoly](https://www.aclu.org/news/free-speech/app-store-oligopoly)
+- "Application Gatekeeping: An Ever-Expanding Pathway to Internet Censorship" — [https://www.eff.org/deeplinks/2025/11/application-gatekeeping-ever-expanding-pathway-internet-censorship](https://www.eff.org/deeplinks/2025/11/application-gatekeeping-ever-expanding-pathway-internet-censorship)
+- "What We Talk About When We Talk About Sideloading" — [https://f-droid.org/en/2025/10/28/sideloading.html](https://f-droid.org/en/2025/10/28/sideloading.html) ([Hacker News Thread](https://news.ycombinator.com/item?id=45736479))
+- "F-Droid and Google's Developer Registration Decree" — [https://f-droid.org/en/2025/09/29/google-developer-registration-decree.html](https://f-droid.org/en/2025/09/29/google-developer-registration-decree.html) ([Hacker News Thread](https://news.ycombinator.com/item?id=45409794))
+- "Pluralistic: Darth Android" — [https://pluralistic.net/2025/09/01/fulu/](https://pluralistic.net/2025/09/01/fulu/)
+- "Google plans to block side-loading like Apple, declaring war on Android freedom" — [https://tuta.com/blog/android-side-load-apps-google](https://tuta.com/blog/android-side-load-apps-google)
+- "Keep Android Free and Open" - [https://www.swechaap.org/blog/keep-android-free-and-open/](https://www.swechaap.org/blog/keep-android-free-and-open)
+- "Join The Protest Against The Closing Of Android" - [https://www.i-programmer.info/news/193-android/18419-join-the-protest-against-the-closing-of-android.html](https://www.i-programmer.info/news/193-android/18419-join-the-protest-against-the-closing-of-android.html)
+
+### ปฏิกิริยาของสื่อ
+
+- "'Keep Android Open' movement fights back against Google sideloading restrictions" – [https://www.theregister.com/2025/10/29/keep_android_open_movement/](https://www.theregister.com/2025/10/29/keep_android_open_movement/)
+- "Resistance to Google's Android verification grows among developers" – [https://www.techzine.eu/news/devops/135878/resistance-to-googles-android-verification-grows-among-developers/](https://www.techzine.eu/news/devops/135878/resistance-to-googles-android-verification-grows-among-developers/)
+- "'Keep Android Open' Movement Challenges Google's Developer Verification Rule" — [https://www.opensourceforu.com/2025/10/keep-android-open-movement-challenges-googles-developer-verification-rule/](https://www.opensourceforu.com/2025/10/keep-android-open-movement-challenges-googles-developer-verification-rule/)
+- "Google kneecaps indie Android devs, forces them to register" — [https://www.theregister.com/2025/08/26/android_developer_verification_sideloading/](https://www.theregister.com/2025/08/26/android_developer_verification_sideloading/)
+- "Open-Source Android Apps at Risk Under Google's New Decree" — [https://www.techrepublic.com/article/news-f-droid-warns-google-developer-decree-open-source-android/](https://www.techrepublic.com/article/news-f-droid-warns-google-developer-decree-open-source-android/)
+- "Google's New Developer ID Rule Could Harm F-Droid, Says Open-Source Advocate" — [https://reclaimthenet.org/googles-android-id-rule-threatens-f-droids-future](https://reclaimthenet.org/googles-android-id-rule-threatens-f-droids-future)
+- "Google's developer registration 'decree' means the end for alternative app stores" — [https://cybernews.com/tech/googles-developer-registration-decree-end-alternative-app-stores/](https://cybernews.com/tech/googles-developer-registration-decree-end-alternative-app-stores/)
+- "Open-Source Android Apps Threatened by Google's New Policy" — [https://www.datamation.com/open-source/android-apps-google-policy/](https://www.datamation.com/open-source/android-apps-google-policy/)
+- "Google's new ID requirements could destroy independent app stores" — [https://www.techspot.com/news/109728-google-confirms-new-android-rules-significantly-restrict-app.html](https://www.techspot.com/news/109728-google-confirms-new-android-rules-significantly-restrict-app.html)
+- "Google's Requirement For All Android Developers To Register And Be Verified Threatens To Close Down Open Source App Store F-Droid" — [https://www.techdirt.com/2025/10/07/googles-requirement-for-all-android-developers-to-register-and-be-verified-threatens-to-close-down-open-source-app-store-f-droid/](https://www.techdirt.com/2025/10/07/googles-requirement-for-all-android-developers-to-register-and-be-verified-threatens-to-close-down-open-source-app-store-f-droid/)
+- "Google's new developer rules could threaten sideloading and F-Droid's future" — [https://www.gizmochina.com/2025/09/30/googles-new-developer-rules-could-threaten-sideloading-and-f-droids-future/](https://www.gizmochina.com/2025/09/30/googles-new-developer-rules-could-threaten-sideloading-and-f-droids-future/)
+- "Google is restricting one of Android's most important features, and users are outraged" — [https://www.slashgear.com/1962802/google-restricting-important-android-feature-reason-why-users-outraged/](https://www.slashgear.com/1962802/google-restricting-important-android-feature-reason-why-users-outraged/)
+- "Android's sideloading limits are its most anti-consumer move yet" - [https://www.makeuseof.com/androids-sideloading-limits-are-anti-consumer-move-yet/](https://www.makeuseof.com/androids-sideloading-limits-are-anti-consumer-move-yet/)
+- "Google's dev registration plan 'will end the F-Droid project'" — [https://www.theregister.com/2025/09/29/googles_dev_registration_plan_will/](https://www.theregister.com/2025/09/29/googles_dev_registration_plan_will/)
+- "F-Droid says Google's new sideloading restrictions will kill the project" — [https://arstechnica.com/gadgets/2025/09/f-droid-calls-for-regulators-to-stop-googles-crackdown-on-sideloading/](https://arstechnica.com/gadgets/2025/09/f-droid-calls-for-regulators-to-stop-googles-crackdown-on-sideloading/)
+- "Google will require developer verification for Android apps outside the Play Store" — [https://techcrunch.com/2025/08/25/google-will-require-developer-verification-for-android-apps-outside-the-play-store/](https://techcrunch.com/2025/08/25/google-will-require-developer-verification-for-android-apps-outside-the-play-store/)
+- "Google will verify Android developers distributing apps outside the Play store" — [https://www.theverge.com/news/765881/google-android-apps-side-loading-developer-verification](https://www.theverge.com/news/765881/google-android-apps-side-loading-developer-verification)
+- "Google will require developer verification to install Android apps, including sideloading" — [https://9to5google.com/2025/08/25/android-apps-developer-verification/](https://9to5google.com/2025/08/25/android-apps-developer-verification/)
+- "Android Security or Vendor Lock-In? Google's New Sideloading Rules Smell Fishy" — [https://news.itsfoss.com/new-android-sideloading-rules/](https://news.itsfoss.com/new-android-sideloading-rules/)
+- "Google Demands Dev Identity For All Android Apps" - [https://www.i-programmer.info/news/193-android/18276-google-demands-dev-identity-for-all-android-apps.html](https://www.i-programmer.info/news/193-android/18276-google-demands-dev-identity-for-all-android-apps.html)
+- "Google Defends Developer Verification" - [https://www.i-programmer.info/news/193-android/18356-google-defends-developer-verification.html](https://www.i-programmer.info/news/193-android/18356-google-defends-developer-verification.html)
+- "Keep Android Open – Abwehr gegen Verbot anonymer Apps von Google" - [https://www.heise.de/news/Keep-Android-Open-Abwehr-gegen-Verbot-anonymer-Apps-von-Google-10965483.html](https://www.heise.de/news/Keep-Android-Open-Abwehr-gegen-Verbot-anonymer-Apps-von-Google-10965483.html)
+
+### การตอบสนองทางวิดีโอ
+
+- "Google: 'Your $1000 phone needs our permission to install apps now'" — Louis Rossmann — [https://youtu.be/QBEKlIV_70E](https://youtu.be/QBEKlIV_70E)
+- "F-Droid Will Die in 2026 Unless We Act Now — Techlore" — [https://youtu.be/wRvqdLsnsKY](https://youtu.be/wRvqdLsnsKY)
+- "Google is Removing Sideloading" — LMG Clips — [https://youtu.be/-R76VJtTDJ8](https://youtu.be/-R76VJtTDJ8)
+- "Google's changes to sideloading could end F-Droid - Linux Weekly News" — [https://youtu.be/iMqpm2Ahmt0](https://youtu.be/iMqpm2Ahmt0)
+- "Is F-Droid in Trouble? Google Developer Verification" — [https://youtu.be/-SOOoQWv4kk](https://youtu.be/-SOOoQWv4kk)
+- "Google is Applefying Android: The End of Openness" — ChiefGyk3D — [https://youtu.be/WFOPzixHoLY](https://youtu.be/WFOPzixHoLY)
+
+### การอภิปราย
+
+- [https://news.ycombinator.com/item?id=45742488](https://news.ycombinator.com/item?id=45742488)
+- [https://news.ycombinator.com/item?id=45409794](https://news.ycombinator.com/item?id=45409794)
+- [https://news.ycombinator.com/item?id=45507173](https://news.ycombinator.com/item?id=45507173)
+- [https://news.ycombinator.com/item?id=45569371](https://news.ycombinator.com/item?id=45569371)
+- [https://news.ycombinator.com/item?id=45742488](https://news.ycombinator.com/item?id=45742488)
+- [https://lobste.rs/s/x1sdu5/f_droid_google_s_developer_registration](https://lobste.rs/s/x1sdu5/f_droid_google_s_developer_registration)
+- [https://www.reddit.com/r/androiddev/comments/1n1m699/horrible_news/](https://www.reddit.com/r/androiddev/comments/1n1m699/horrible_news/)
+- [https://www.reddit.com/r/androiddev/comments/1n3jtrf/google_you_royally_screwed_up/](https://www.reddit.com/r/androiddev/comments/1n3jtrf/google_you_royally_screwed_up/)
+- [https://www.reddit.com/r/androiddev/comments/1n0uy6g/just_received_this_email_now_you_can_get/](https://www.reddit.com/r/androiddev/comments/1n0uy6g/just_received_this_email_now_you_can_get/)
+- [https://www.reddit.com/r/androiddev/comments/1n2im4j/this_may_mark_the_end_of_android_development_for/](https://www.reddit.com/r/androiddev/comments/1n2im4j/this_may_mark_the_end_of_android_development_for/)
+- [https://www.reddit.com/r/androiddev/comments/1n0f41c/google_will_require_developer_verification_to/](https://www.reddit.com/r/androiddev/comments/1n0f41c/google_will_require_developer_verification_to/)
+- [https://www.reddit.com/r/androiddev/comments/1km8jof/google_play_developer_verification/](https://www.reddit.com/r/androiddev/comments/1km8jof/google_play_developer_verification/)
+- [https://www.reddit.com/r/androiddev/comments/1mzw877/android_developers_blog_a_new_layer_of_security/](https://www.reddit.com/r/androiddev/comments/1mzw877/android_developers_blog_a_new_layer_of_security/)
+- [https://www.reddit.com/r/androiddev/comments/1n7g0cc/to_all_android_devs_speak_up_now_before_you_lose/](https://www.reddit.com/r/androiddev/comments/1n7g0cc/to_all_android_devs_speak_up_now_before_you_lose/)
+- [https://www.reddit.com/r/androiddev/comments/1oaj908/collection_of_actions_we_can_take_to_stop/](https://www.reddit.com/r/androiddev/comments/1oaj908/collection_of_actions_we_can_take_to_stop/)
+- [https://www.reddit.com/r/androiddev/comments/1n4888u/psa_google_is_requiring_verification/](https://www.reddit.com/r/androiddev/comments/1n4888u/psa_google_is_requiring_verification/)
+- [https://www.reddit.com/r/Fediverse/comments/214y4q/google_is_attempting_to_kill_fediverse_apps_like/](https://www.reddit.com/r/Fediverse/comments/214y4q/google_is_attempting_to_kill_fediverse_apps_like/)
+- [https://www.reddit.com/r/rootapps/comments/1n47z2x/google_is_killing_android_as_we_know_it/](https://www.reddit.com/r/rootapps/comments/1n47z2x/google_is_killing_android_as_we_know_it/)
+- [https://www.reddit.com/r/opensource/comments/1n4895w/google_is_killing_open_source_on_android/](https://www.reddit.com/r/opensource/comments/1n4895w/google_is_killing_open_source_on_android/)
+- [https://www.reddit.com/r/Android/comments/1n4896t/google_is_killing_android_as_we_know_it/](https://www.reddit.com/r/Android/comments/1n4896t/google_is_killing_android_as_we_know_it/)
+- [https://www.reddit.com/r/Android/comments/1n4896t/google_is_killing_android_as_we_know_it/](https://www.reddit.com/r/Android/comments/1n4896t/google_is_killing_android_as_we_know_it/)
+
+### คำแนะนำเพิ่มเติม
+
+- ดาวน์โหลดตัวอย่างใหม่ของ Android Developer Console — [https://support.google.com/android-developer-console/answer/16450960](https://support.google.com/android-developer-console/answer/16450960)
+- [การอภิปรายเกี่ยวกับการตรวจสอบตัวตนของนักพัฒนาAndroid](https://gist.github.com/agnostic-apollo/b8d8daa24cbdd216687a6bef53d417a6) โดยนักพัฒนา Termux [agnostic-apollo](https://github.com/agnostic-apollo)

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -7,6 +7,7 @@ export const languages = {
   'pt-BR': { label: 'Português', path: '/pt-BR/' },
   cs: { label: 'Čeština', path: '/cs/' },
   sk: { label: 'Slovenčina', path: '/sk/' },
+  th: { label: 'ไทย', path: '/th/' },
   tr: { label: 'Türkçe', path: '/tr/' },
   uk: { label: 'Українська', path: '/uk/' },
   'zh-CN': { label: '简体中文', path: '/zh-CN/' },


### PR DESCRIPTION
1. Added Thai translation
2. Added links to
    1.  Electronic Transaction Development Agency (ETDA) .
    2.  Thailand Consumers Council (TCC) .

I've translated the main idea of the page. However, it would still need some hands on polishing the words and make sentences easier to understand. I'm not quite aware what contact points could also be added.
