### PR TITLE
README: removed redundant (and broken) link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Keep Android Open
 
 **Keep Android Open** is a [community advocacy website](https://keepandroidopen.org) fighting against Google's 2025 developer verification mandate, which will require all developers to be registered with Google.
-You can find more details [here](/index.md).
 
 ## Purpose
 


### PR DESCRIPTION
The README points ot the site, and then says that "You can find more details here", where 'here' is a link to the site's main page, which would be redundant... if the link pointed to the right place.

Removing that sentence does not remove any information to the readers, and removes a broken link.

If you don't want to accept this PR because you want to keep the sentence there, the link should at least be fixed.