### PR TITLE
Fixed Rossmann spelling

### DIFF
--- a/src/data/signatures.yaml
+++ b/src/data/signatures.yaml
@@ -134,7 +134,7 @@
   url: "proton.me"
   poc: "Samuele Kaplun <samuele.kaplun@proton.ch>"
   region: CH
-- organization: "Rossman Group"
+- organization: "Rossmann Group"
   url: "rossmanngroup.com"
   poc: "Louis Rossmann <youtube@rossmanngroup.com>"
   region: US


### PR DESCRIPTION
Fixed the spelling of "Rossman" to "Rossmann" before Louis notices