### PR TITLE
Add LibreTube signature

### DIFF
--- a/src/data/signatures.yaml
+++ b/src/data/signatures.yaml
@@ -158,6 +158,10 @@
   url: "vivaldi.com"
   poc: "Jon von Tetzchner <jon@vivaldi.com>"
   region: "NO"
+- organization: "LibreTube"
+  url: "libretube.dev"
+  poc: "libretube@proton.me"
+  region: "NO"
 
 #- organization: "XXX"
 #  url: "XXX"


### PR DESCRIPTION
Adds the signature of the [LibreTube project](https://github.com/libre-tube/LibreTube), an alternative Android client for YouTube.

Let me know if that it is enough that I'm a maintainer of the git repo/org member, or if we should send any other confirmation (e.g. email).