### PR TITLE
Add digitalprivacy.diy signature

### DIFF
--- a/src/data/signatures.yaml
+++ b/src/data/signatures.yaml
@@ -158,6 +158,10 @@
   url: "vivaldi.com"
   poc: "Jon von Tetzchner <jon@vivaldi.com>"
   region: "NO"
+- organization: "DIGITAL PRIVACY .DIY"
+  url: "digitalprivacy.diy"
+  poc: "DIGITAL PRIVACY .DIY <keepandroidopen@digitalprivacy.diy>"
+  region: "NZ/DE"
 
 #- organization: "XXX"
 #  url: "XXX"


### PR DESCRIPTION
Adds the signature from [digitalprivacy.diy](https://digitalprivacy.diy). Provides some open source services and offers some guides/tutorials, including for Android.