### PR TITLE
Clarify signature policy

### DIFF
--- a/src/data/signatures.yaml
+++ b/src/data/signatures.yaml
@@ -1,3 +1,10 @@
+# Please do not file pull requests adding signatures to this file.
+#
+# Signatures from notable organzations (e.g., with a Wikipedia entry)
+# should be emailed to signatories@keepandroidopen.org by an
+# authorized representative of the group with an attestation that
+# the organization's leadership authorized the signing of the letter.
+
 #- organization: ""
 #  url: ""
 #  poc: ""


### PR DESCRIPTION
This PR clarifies that signatures should not be submitted via pull requests, but rather emailed by an authorized representative of the organization.