### PR TITLE
add missing, but required top-level dependency `unist-util-visit`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "rehype-autolink-headings": "^7.1.0",
     "rehype-external-links": "^3.0.0",
     "rehype-slug": "^6.0.0",
-    "remark-custom-heading-id": "^2.0.0"
+    "remark-custom-heading-id": "^2.0.0",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
     "@rollup/plugin-yaml": "^4.1.2"


### PR DESCRIPTION
Previously this package was only installed as a dependency of another dependency, meaning package managers not using a flat node_modules (e.g. pnpm) didn't properly install it