### PR TITLE
Update zh-CN translation for Taiwan

### DIFF
--- a/src/data/regulators.yaml
+++ b/src/data/regulators.yaml
@@ -2166,7 +2166,7 @@ countries:
       uk: "Тайвань"
       pl: "Tajwan"
       pt-BR: "Taiwan"
-      zh-CN: "中国台湾"
+      zh-CN: "台湾"
       zh-TW: "臺灣"
       ja: "台湾"
     items:


### PR DESCRIPTION
Using "Mainland China" (中国大陆/中國大陸) and "Taiwan" (台湾/臺灣/台灣) respectively refer to PRC and ROC is a common practice by Chinese-speaking multi-region projects to avoid political disputes. (e.g. [BYVoid/OpenCC](https://github.com/BYVoid/OpenCC), [Chinese Wikipedia](https://zh.wikipedia.org/wiki/Wikipedia:%E6%A0%BC%E5%BC%8F%E6%89%8B%E5%86%8C/%E4%B8%A4%E5%B2%B8%E5%9B%9B%E5%9C%B0%E7%94%A8%E8%AF%AD).) Using "中国台湾" (Chinese Taiwan) is controversial and would be offensive to many Taiwanese.