### PR TITLE
Add de-CH variant to supported locales

### DIFF
--- a/public/banner.js
+++ b/public/banner.js
@@ -30,6 +30,7 @@
     ca:      "Android es convertir\u00E0 en una plataforma tancada",
     cs:      "Android will become a locked-down platform in",
     de:      "Android wird eine geschlossene Plattform werden.",
+    "de-CH": "Android wird eine geschlossene Plattform werden.",
     da:      "Android vil blive en lukket platform om",
     nl:      "Android zal een gesloten platform worden over",
     el:      "\u03A4\u03BF Android \u03B8\u03B1 \u03B3\u03AF\u03BD\u03B5\u03B9 \u03BC\u03AF\u03B1 \u03BA\u03BB\u03B5\u03B9\u03C3\u03C4\u03AE \u03C0\u03BB\u03B1\u03C4\u03C6\u03CC\u03C1\u03BC\u03B1",


### PR DESCRIPTION
The banner does not display the german translation if your browser/os uses german with swiss grammar (de-CH), so I added it.
It's effectively the same as german itself, so if there's a simpler way for less duplication lmk.