### PR TITLE
Update title for French index page

### DIFF
--- a/src/content/pages/fr/index.md
+++ b/src/content/pages/fr/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Keep Android Open"
+title: "Keep Android Open - _Garder Android ouvert_"
 lang: fr
 description: "Plaidoyer pour Android en tant que plateforme libre et ouverte permettant à tous de développer des applications."
 


### PR DESCRIPTION
This pull request updates the French homepage title to include both English and French versions, improving clarity and accessibility for bilingual users.

* Content update:
  * [`src/content/pages/fr/index.md`](diffhunk://#diff-00614cc6f468406c3755b83ca2b377eb3c113ef452ccd917adbdae8579fe1e19L2-R2): Modified the `title` field to display both English and French ("Keep Android Open - _Garder Android ouvert_").