### PR TITLE
Add the Colombian Superintendence of Industry and Commerce

### DIFF
--- a/src/data/regulators.yaml
+++ b/src/data/regulators.yaml
@@ -3182,3 +3182,13 @@ countries:
       - text:
           en: "Contact the [Hungarian Competition Authority (Gazdasági Versenyhivatal)](https://www.gvh.hu/en/gvh/2361_en_contact_us)"
           hu: "Vedd fel a kapcsolatot a [Gazdasági Versenyhivatallal](https://www.gvh.hu/gvh/2361_hu_elerhetosegek_kapcsolatok)"
+  - id: colombia
+    name:
+      en: "Colombia"
+      es: "Colombia"
+      pt-BR: "Colômbia"
+    items:
+      - text:
+          en: Make a report to the [Superintendence of Industry and Commerce](https://servicioslinea.sic.gov.co/servilinea/pqrsf/)
+          es: Presentar una denuncia ante la [Superintendencia de Industria y Comercio](https://servicioslinea.sic.gov.co/servilinea/pqrsf/)
+          pt-BR: Faça um relato para a [Superintendência de Indústria e Comércio](https://servicioslinea.sic.gov.co/servilinea/pqrsf/)


### PR DESCRIPTION
Hello,

As requested in https://github.com/keepandroidopen/keepandroidopen.github.io/issues/165, this PR adds the Colombian regulator to the website (see screenshot below). If any other files should be updated, feel free to update the PR or reach out to me.

<img width="1094" height="659" alt="image" src="https://github.com/user-attachments/assets/acbb7e1e-d994-4c6b-a439-e8780dfcb89b" />

This PR closes https://github.com/keepandroidopen/keepandroidopen.github.io/issues/165

TIA,
Leo.