### PR TITLE
Add Aotearoa/NZ regulators, update advanced flow blurb

### DIFF
--- a/src/content/pages/en/index.md
+++ b/src/content/pages/en/index.md
@@ -51,6 +51,14 @@ Contrary to a vague [mention](https://android-developers.googleblog.com/2025/11/
 
 Until such time that they have shown evidence that it will be possible to bypass the verification process without undue friction, we must believe what is stated on their official page: that **all** apps from non-registered developers **will be blocked** once their lock-down goes into effect.
 
+### Update: Google has revealed the "advanced flow" — it is not a solution
+
+On March 19, 2026, Google published details of the "advanced flow" the mechanism intended to allow installation of applications from unverified developers after the mandate takes effect. This flow requires enabling Developer Mode, self-attesting that you are not being coerced, restarting your device, and waiting a mandatory 24 hours before being permitted to install applications from unverified sources. Critically, the entire flow is delivered via Google Play Services — not the Android OS — meaning Google can modify, restrict, or remove it at any time without an OS update and without user consent.
+
+The advanced flow has still not appeared in any Android beta, dev preview, or canary release. As of the date of this update, it exists only as a blog post and UI mockups. The community is being asked to accept a product announcement as a functional safeguard five months before the mandate takes effect.
+
+Until Google provides a shipping implementation that can be independently verified, the position of this site remains unchanged: **all** apps from non-registered developers **will be blocked** once their lockdown goes into effect in September 2026.
+
 </div>
 
 ## How you can help {#help}

--- a/src/data/regulators.yaml
+++ b/src/data/regulators.yaml
@@ -2303,6 +2303,24 @@ countries:
           pt-BR: "Entre em contato com seu deputado local ou senador estadual. Se você não souber seu eleitorado, pode encontrá-lo [aqui](https://electorate.aec.gov.au/) e pode buscar seus parlamentares ou senadores [aqui](https://www.aph.gov.au/Senators_and_Members/Parliamentarian_Search_Results)."
           zh-CN: "联系您当地的国会议员或州参议员。如果您不知道您的选区，可以在[这里](https://electorate.aec.gov.au/)找到；您可以在[这里](https://www.aph.gov.au/Senators_and_Members/Parliamentarian_Search_Results)搜索您的国会议员或参议员。"
           zh-TW: "聯絡您當地的國會議員或州參議員。如果您不知道您的選區，可以在[這裡](https://electorate.aec.gov.au/)找到；您可以在[這裡](https://www.aph.gov.au/Senators_and_Members/Parliamentarian_Search_Results)搜尋您的國會議員或參議員。"
+  - id: new-zealand
+    name:
+      en: "Aotearoa / New Zealand"
+    items:
+      - text:
+          en: "Email: [contact@comcom.govt.nz](mailto:contact@comcom.govt.nz?cc=nz@keepandroidopen.org)"
+      - text:
+          en: "Phone: [0800 943 600](tel:08009436000)"
+      - text:
+          en: "Report anti-competitive conduct to the [Commerce Commission](https://www.comcom.govt.nz/report-a-concern/)"
+      - text:
+          en: "Contact the Minister of Commerce and Consumer Affairs, Hon Scott Simpson: [scott.simpson@parliament.govt.nz](mailto:scott.simpson@parliament.govt.nz)"
+      - text:
+          en: "Contact your local Member of Parliament. If you don't know your electorate, find it at [vote.nz](https://www.vote.nz)"
+      - text:
+          en: "Contact [InternetNZ](https://internetnz.nz) — the non-profit advocate for an open internet in Aotearoa: [office@internetnz.net.nz](mailto:office@internetnz.net.nz)"
+      - text:
+          en: "Contact [Consumer NZ](https://www.consumer.org.nz/about/contact-us) — Aotearoa's independent consumer advocacy organisation. Ask them to lodge a formal complaint to the Commerce Commission on behalf of consumers."
   - id: japan
     name:
       fa: "ژاپن"


### PR DESCRIPTION
This PR makes two contributions:

1. Aotearoa / New Zealand regulators

NZ was not represented in the regulators section. Added entries for:

    Commerce Commission (primary competition regulator) - contact form, phone, email
    Minister of Commerce and Consumer Affairs, Hon Scott Simpson
    Local MP finder via vote.nz
    InternetNZ - open internet advocacy non-profit
    Consumer NZ - independent consumer advocacy organisation

Note for maintainers: nz@keepandroidopen.org needs to be created to match the CC pattern used by other countries. I have added it with the belief that this should be a simple fix on your end

2. Updated advanced flow blurb

The existing update callout referenced only the November 2025 vague mention of the advanced flow. A second update has been added beneath it reflecting the March 19, 2026 Google blog post which revealed the full advanced flow details. The original callout has been preserved as the historical position. The new addition makes clear that the advanced flow remains inadequate and unshipped.