### PR TITLE
Fix pt-br and es banner

### DIFF
--- a/public/banner.js
+++ b/public/banner.js
@@ -42,7 +42,7 @@
     it:      "Android diventer\u00E0 una piattaforma bloccata",
     ko:      "Android\uAC00 \uD3D0\uC1C4\uB41C \uD50C\uB7AB\uD3FC\uC774 \uB418\uAE30\uAE4C\uC9C0 \uB0A8\uC740 \uC2DC\uAC04:",
     pl:      "Android stanie si\u0119 platform\u0105 zamkni\u0119t\u0105 za",
-    "pt-BR": "O Android se tornar\u00E1 uma plataforma fechada",
+    "pt-BR": "O Android se tornar\u00E1 uma plataforma fechada em",
     ru:      "Android \u0441\u0442\u0430\u043D\u0435\u0442 \u0437\u0430\u043A\u0440\u044B\u0442\u043E\u0439 \u043F\u043B\u0430\u0442\u0444\u043E\u0440\u043C\u043E\u0439 \u0447\u0435\u0440\u0435\u0437",
     sk:      "Android sa stane uzamknutou platformou",
     th:      "Android\u0E08\u0E30\u0E40\u0E1B\u0E47\u0E19\u0E41\u0E1E\u0E25\u0E15\u0E1F\u0E2D\u0E23\u0E4C\u0E21\u0E17\u0E35\u0E48\u0E16\u0E39\u0E01\u0E25\u0E47\u0E2D\u0E01",


### PR DESCRIPTION
Inspired by https://github.com/keepandroidopen/keepandroidopen.github.io/pull/236, this PR also fixes the missing "in" in both Portuguese and Spanish banner messages

Regards,
Leo.