### PR TITLE
fix: preserve language casing in /cta routes

### DIFF
--- a/src/pages/[locale]/cta.astro
+++ b/src/pages/[locale]/cta.astro
@@ -14,7 +14,8 @@ export async function getStaticPaths() {
     .filter((page) => page.id !== 'letter')
     .filter((page) => page.id !== 'banner')
     .map((page) => {
-      const locale = page.id;
+      // Prefer the declared language tag so locales like zh-TW / pt-BR keep casing.
+      const locale = page.data.lang || page.id;
       return { params: { locale }, props: { entry: page } };
     });
 }


### PR DESCRIPTION
Fix localized CTA route casing to prevent 404 on uppercase locale paths (e.g. /zh-TW/cta/, /pt-BR/cta/) by using frontmatter `lang` for route params.