### PR TITLE
Modernize banner with backwards-compatible style=classic opt-out

### DIFF
--- a/public/banner.js
+++ b/public/banner.js
@@ -10,16 +10,19 @@
  *   <script src="https://keepandroidopen.org/banner.js"></script>
  *
  * Query parameters (appended to the script src URL):
- *   lang=fr       Override the browser language (default: auto-detected)
- *   id=myDiv      Insert the banner inside the element with this id
- *                 (default: prepend to <body>)
- *   size=normal   Banner size: "normal" (default), "mini" or "minimal"
- *   link=URL      Make the banner text a link (default: https://keepandroidopen.org)
- *                 Set link=none to disable the link
- *   hidebutton=on Show an X close button (default: on)
- *                 Set hidebutton=off to hide the close button
- *   animation=on  Add animation to border of banner (default: on)
- *                 Set animation=off to disable
+ *   lang=fr        Override the browser language (default: auto-detected)
+ *   id=myDiv       Insert the banner inside the element with this id
+ *                  (default: prepend to <body>)
+ *   size=normal    Banner size: "normal" (default), "mini" or "minimal"
+ *   link=URL       Make the banner text a link (default: https://keepandroidopen.org)
+ *                  Set link=none to disable the link
+ *   hidebutton=on  Show an X close button (default: on)
+ *                  Set hidebutton=off to hide the close button
+ *   animation=on   Add animation to the banner (default: on)
+ *                  Set animation=off to disable
+ *   theme=auto     Color theme: "auto" (default), "light", or "dark"
+ *   style=modern   Visual style: "modern" (default) or "classic"
+ *                  classic = the pre-2026 bold all-caps red design
  */
 (function () {
   "use strict";
@@ -30,32 +33,32 @@
     ar:      "سيصبح نظام أندرويد منصة مغلقة في",
     he:      "אנדרואיד תהפוך לפלטפורמה נעולה בעוד",
     en:      "Android will become a locked-down platform in",
-    ca:      "Android es convertir\u00E0 en una plataforma tancada",
+    ca:      "Android es convertirà en una plataforma tancada",
     cs:      "Android se stane uzamčenou platformou za",
     de:      "Android wird eine geschlossene Plattform werden.",
     da:      "Android vil blive en lukket platform om",
     nl:      "Android zal een gesloten platform worden over",
-    el:      "\u03A4\u03BF Android \u03B8\u03B1 \u03B3\u03AF\u03BD\u03B5\u03B9 \u03BC\u03AF\u03B1 \u03BA\u03BB\u03B5\u03B9\u03C3\u03C4\u03AE \u03C0\u03BB\u03B1\u03C4\u03C6\u03CC\u03C1\u03BC\u03B1",
-    es:      "Android se convertir\u00E1 en una plataforma cerrada en",
-    fr:      "Android va devenir une plateforme ferm\u00E9e dans",
+    el:      "Το Android θα γίνει μία κλειστή πλατφόρμα",
+    es:      "Android se convertirá en una plataforma cerrada en",
+    fr:      "Android va devenir une plateforme fermée dans",
     id:      "Android akan menjadi platform yang terkunci.",
-    it:      "Android diventer\u00E0 una piattaforma bloccata",
-    ko:      "Android\uAC00 \uD3D0\uC1C4\uB41C \uD50C\uB7AB\uD3FC\uC774 \uB418\uAE30\uAE4C\uC9C0 \uB0A8\uC740 \uC2DC\uAC04:",
-    pl:      "Android stanie si\u0119 platform\u0105 zamkni\u0119t\u0105 za",
-    "pt-BR": "O Android se tornar\u00E1 uma plataforma fechada em",
-    ru:      "Android \u0441\u0442\u0430\u043D\u0435\u0442 \u0437\u0430\u043A\u0440\u044B\u0442\u043E\u0439 \u043F\u043B\u0430\u0442\u0444\u043E\u0440\u043C\u043E\u0439 \u0447\u0435\u0440\u0435\u0437",
+    it:      "Android diventerà una piattaforma bloccata",
+    ko:      "Android가 폐쇄된 플랫폼이 되기까지 남은 시간:",
+    pl:      "Android stanie się platformą zamkniętą za",
+    "pt-BR": "O Android se tornará uma plataforma fechada em",
+    ru:      "Android станет закрытой платформой через",
     sk:      "Android sa stane uzamknutou platformou",
-    th:      "Android\u0E08\u0E30\u0E40\u0E1B\u0E47\u0E19\u0E41\u0E1E\u0E25\u0E15\u0E1F\u0E2D\u0E23\u0E4C\u0E21\u0E17\u0E35\u0E48\u0E16\u0E39\u0E01\u0E25\u0E47\u0E2D\u0E01",
-    tr:      "Android k\u0131s\u0131tl\u0131 bir platform haline gelecek.",
-    uk:      "Android \u0441\u0442\u0430\u043D\u0435 \u0437\u0430\u043A\u0440\u0438\u0442\u043E\u044E \u043F\u043B\u0430\u0442\u0444\u043E\u0440\u043C\u043E\u044E",
-    "zh-CN": "\u5B89\u5353\u5C06\u6210\u4E3A\u4E00\u4E2A\u5C01\u95ED\u5E73\u53F0",
-    "zh-TW": "Android \u5C07\u6210\u70BA\u4E00\u500B\u5C01\u9589\u5E73\u53F0",
+    th:      "Androidจะเป็นแพลตฟอร์มที่ถูกล็อก",
+    tr:      "Android kısıtlı bir platform haline gelecek.",
+    uk:      "Android стане закритою платформою",
+    "zh-CN": "安卓将成为一个封闭平台",
+    "zh-TW": "Android 將成為一個封閉平台",
     ja:      "Androidは閉鎖的なプラットフォームになろうとしています",
     fi:      "Androidista tulee suljettu alusta",
     hu:      "Az Android egy lezárt platform lesz",
     vi:      "Android sẽ trở thành một hệ điều hành đóng",
     bg:      "Android ще стане заключена платформа след",
-    be:      "Android \u0441\u0442\u0430\u043d\u0435 \u0437\u0430\u043a\u0440\u044b\u0442\u0430\u0439 \u043f\u043b\u0430\u0444\u0442\u043e\u0440\u043c\u0430\u0439 \u0020 \u0020",
+    be:      "Android стане закрытай плафтормай    ",
   };
 
   // ── Parse query parameters from the script's own src URL ──────────────
@@ -112,6 +115,15 @@
         ? "minimal"
         : "normal";
 
+  // ── Theme (new) ───────────────────────────────────────────────────────
+  var theme = params.theme === "dark" ? "dark"
+      : params.theme === "light"
+        ? "light"
+        : "auto";
+
+  // ── Style (new): "modern" (default) or "classic" (the original look) ──
+  var styleMode = params.style === "classic" ? "classic" : "modern";
+
   // ── Link ────────────────────────────────────────────────────────────
   var linkParam = params.link;
   var defaultLink = "https://keepandroidopen.org" + (locale === "en" ? "" : "/" + locale + "/");
@@ -121,10 +133,207 @@
   var showClose = params.hidebutton !== "off";
   var storageKey = "kao-banner-hidden";
   var dismissDays = 30;
+  var noAnim = params.animation === "off";
 
-  // ── Inject CSS ────────────────────────────────────────────────────────
-  var cssNormal =
-    ".kao-banner{" +
+  // ── CSS: tokens (light + dark + auto) ────────────────────────────────
+  var cssTokens =
+    ".kao-banner.kao-banner--style-modern{" +
+      "--kao-bg-from:#fff1d0;--kao-bg-to:#ffe1a0;" +
+      "--kao-fg:#4a3000;--kao-fg-strong:#2a1a00;" +
+      "--kao-accent:#b85d00;--kao-accent-strong:#7a3d00;" +
+      "--kao-border:rgba(184,93,0,.32);--kao-pill-bg:rgba(184,93,0,.14);" +
+      "--kao-stripe:rgba(184,93,0,.10);--kao-glow:rgba(255,184,77,.45);" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern.kao-banner--theme-dark{" +
+      "--kao-bg-from:#2a1f08;--kao-bg-to:#3a2c10;" +
+      "--kao-fg:#ffd9a3;--kao-fg-strong:#fff1dc;" +
+      "--kao-accent:#ffb84d;--kao-accent-strong:#ffce80;" +
+      "--kao-border:rgba(255,184,77,.34);--kao-pill-bg:rgba(255,184,77,.14);" +
+      "--kao-stripe:rgba(255,184,77,.10);--kao-glow:rgba(255,184,77,.30);" +
+    "}" +
+    "@media(prefers-color-scheme:dark){" +
+      ".kao-banner.kao-banner--style-modern.kao-banner--theme-auto{" +
+        "--kao-bg-from:#2a1f08;--kao-bg-to:#3a2c10;" +
+        "--kao-fg:#ffd9a3;--kao-fg-strong:#fff1dc;" +
+        "--kao-accent:#ffb84d;--kao-accent-strong:#ffce80;" +
+        "--kao-border:rgba(255,184,77,.34);--kao-pill-bg:rgba(255,184,77,.14);" +
+        "--kao-stripe:rgba(255,184,77,.10);--kao-glow:rgba(255,184,77,.30);" +
+      "}" +
+    "}";
+
+  // ── CSS: modern base + reset ────────────────────────────────────────
+  var cssBase =
+    ".kao-banner.kao-banner--style-modern{" +
+      "position:relative;box-sizing:border-box;width:100%;" +
+      "font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica Neue,Arial,sans-serif;" +
+      "font-size:14px;font-weight:400;line-height:1.4;letter-spacing:normal;" +
+      "text-shadow:none;text-transform:none;text-align:start;" +
+      "color:var(--kao-fg);" +
+      "background:" +
+        "repeating-linear-gradient(-45deg,transparent 0,transparent 22px," +
+        "var(--kao-stripe) 22px,var(--kao-stripe) 24px)," +
+        "linear-gradient(95deg,var(--kao-bg-from) 0%,var(--kao-bg-to) 100%);" +
+      "border-bottom:1px solid var(--kao-border);" +
+      "box-shadow:0 6px 18px -10px var(--kao-glow);" +
+      "contain:layout style;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern *{box-sizing:border-box;}" +
+    ".kao-banner.kao-banner--style-modern .kao-banner__inner{" +
+      "position:relative;display:flex;align-items:center;" +
+      "gap:12px;min-width:0;max-width:1200px;margin:0 auto;" +
+      "padding:0 16px;height:100%;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern .kao-banner__icon{" +
+      "flex-shrink:0;width:22px;height:22px;" +
+      "color:var(--kao-accent);" +
+      "filter:drop-shadow(0 1px 2px var(--kao-glow));" +
+      "animation:kao-warn-pulse 2.4s ease-in-out infinite;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern .kao-banner__icon-mark{" +
+      "fill:#1a0e00;" +
+    "}" +
+    "@keyframes kao-warn-pulse{" +
+      "0%,100%{opacity:1;transform:scale(1);}" +
+      "50%{opacity:.78;transform:scale(.94);}" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern .kao-banner__text{" +
+      "margin:0;flex:0 1 auto;min-width:0;overflow:hidden;" +
+      "text-overflow:ellipsis;white-space:nowrap;" +
+      "font-size:.875rem;font-weight:500;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern .kao-banner__brand{" +
+      "font-weight:700;color:var(--kao-fg-strong);" +
+      "text-transform:uppercase;font-size:.8125rem;" +
+      "letter-spacing:.04em;margin-inline-end:6px;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern .kao-banner__verify{" +
+      "opacity:.92;margin-inline-end:6px;color:inherit;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern a.kao-banner__verify{" +
+      "text-decoration:none;color:inherit;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern a.kao-banner__verify:hover{" +
+      "text-decoration:underline;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern .kao-banner__count{" +
+      "flex-shrink:0;margin-inline-start:auto;" +
+      "font-family:ui-monospace,SFMono-Regular,SF Mono,Menlo,Monaco,Consolas,monospace;" +
+      "font-variant-numeric:tabular-nums;font-weight:600;" +
+      "color:var(--kao-accent-strong);padding:2px 7px;border-radius:6px;" +
+      "background:var(--kao-pill-bg);border:1px solid var(--kao-border);" +
+      "font-size:.8125rem;letter-spacing:.02em;white-space:nowrap;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern .kao-banner__cta{" +
+      "display:inline-flex;align-items:center;gap:4px;" +
+      "font-size:.8125rem;font-weight:700;color:var(--kao-accent-strong);" +
+      "text-decoration:none;flex-shrink:0;padding:5px 12px;" +
+      "border-radius:999px;border:1px solid var(--kao-border);" +
+      "background:transparent;" +
+      "transition:background .2s,transform .2s,border-color .2s;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern .kao-banner__cta:hover{" +
+      "background:var(--kao-pill-bg);" +
+      "border-color:var(--kao-accent);" +
+      "transform:translateX(2px);" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern .kao-banner__cta:focus-visible{" +
+      "outline:2px solid var(--kao-fg-strong);outline-offset:2px;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern.kao-banner--has-close .kao-banner__inner{" +
+      "padding-inline-end:40px;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern .kao-banner__close{" +
+      "position:absolute;inset-inline-end:8px;top:50%;" +
+      "transform:translateY(-50%);background:none;border:0;" +
+      "-webkit-appearance:none;appearance:none;cursor:pointer;" +
+      "color:var(--kao-fg);opacity:.6;font-size:14px;line-height:1;" +
+      "padding:6px 8px;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern .kao-banner__close:hover{opacity:1;}" +
+    ".kao-banner.kao-banner--style-modern .kao-banner__close:focus-visible{" +
+      "outline:2px solid var(--kao-fg-strong);outline-offset:2px;opacity:1;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern .kao-banner__a11y-status{" +
+      "position:absolute;width:1px;height:1px;padding:0;margin:-1px;" +
+      "overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;" +
+    "}";
+
+  // ── CSS: modern size variants ────────────────────────────────────────
+  var cssSizes =
+    ".kao-banner.kao-banner--style-modern.kao-banner--normal{height:48px;}" +
+    ".kao-banner.kao-banner--style-modern.kao-banner--mini{height:36px;}" +
+    ".kao-banner.kao-banner--style-modern.kao-banner--mini .kao-banner__icon{" +
+      "width:18px;height:18px;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern.kao-banner--mini .kao-banner__text{" +
+      "font-size:.75rem;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern.kao-banner--mini .kao-banner__brand{" +
+      "font-size:.75rem;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern.kao-banner--mini .kao-banner__count{" +
+      "font-size:.6875rem;padding:1px 5px;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern.kao-banner--minimal{height:28px;}" +
+    ".kao-banner.kao-banner--style-modern.kao-banner--minimal .kao-banner__inner{" +
+      "padding:0 12px;gap:6px;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern.kao-banner--minimal .kao-banner__text{" +
+      "font-size:.75rem;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern.kao-banner--minimal .kao-banner__count{" +
+      "font-size:.6875rem;padding:1px 5px;" +
+    "}";
+
+  // ── CSS: media queries (responsive truncation) ───────────────────────
+  // At narrow widths the verify (and eventually brand) text is hidden, leaving
+  // the text element empty. Drop the count's auto inline-start margin so the
+  // right-side cluster sits next to the brand/icon instead of being pushed to
+  // the far edge — otherwise the layout reads as right-aligned.
+  var cssMedia =
+    "@media(max-width:860px){" +
+      ".kao-banner.kao-banner--style-modern .kao-banner__verify{display:none;}" +
+      ".kao-banner.kao-banner--style-modern .kao-banner__count{margin-inline-start:0;}" +
+    "}" +
+    "@media(max-width:640px){" +
+      ".kao-banner.kao-banner--style-modern.kao-banner--normal{height:44px;}" +
+      ".kao-banner.kao-banner--style-modern .kao-banner__inner{gap:8px;padding:0 12px;}" +
+      ".kao-banner.kao-banner--style-modern.kao-banner--has-close .kao-banner__inner{padding-inline-end:40px;}" +
+      ".kao-banner.kao-banner--style-modern .kao-banner__icon{width:18px;height:18px;}" +
+      ".kao-banner.kao-banner--style-modern .kao-banner__cta__label{display:none;}" +
+      ".kao-banner.kao-banner--style-modern .kao-banner__cta{padding:5px 8px;}" +
+    "}" +
+    "@media(max-width:380px){" +
+      ".kao-banner.kao-banner--style-modern .kao-banner__brand{display:none;}" +
+    "}";
+
+  // ── CSS: motion preferences ──────────────────────────────────────────
+  var cssMotion =
+    "@media(prefers-reduced-motion:reduce){" +
+      ".kao-banner.kao-banner--style-modern .kao-banner__icon{animation:none;}" +
+      ".kao-banner.kao-banner--style-modern .kao-banner__cta{transition:none;}" +
+      ".kao-banner.kao-banner--style-modern .kao-banner__cta:hover{transform:none;}" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern.kao-banner--no-anim .kao-banner__icon{" +
+      "animation:none;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern.kao-banner--no-anim .kao-banner__cta{" +
+      "transition:none;" +
+    "}" +
+    ".kao-banner.kao-banner--style-modern.kao-banner--no-anim .kao-banner__cta:hover{" +
+      "transform:none;" +
+    "}";
+
+  // ── CSS: RTL adjustments ─────────────────────────────────────────────
+  var cssRtl =
+    "[dir=rtl] .kao-banner.kao-banner--style-modern .kao-banner__cta__arrow," +
+    ".kao-banner.kao-banner--style-modern[dir=rtl] .kao-banner__cta__arrow{" +
+      "transform:scaleX(-1);" +
+    "}";
+
+  // ── CSS: classic style (original look preserved 1:1) ─────────────────
+  var cssClassicNormal =
+    ".kao-banner.kao-banner--style-classic.kao-banner--normal{" +
       "position:relative;" +
       "font-variant-numeric:tabular-nums;" +
       "background:linear-gradient(180deg,#d32f2f 0%,#b71c1c 100%);" +
@@ -147,8 +356,8 @@
       "box-sizing:border-box;" +
     "}";
 
-  var cssMini =
-    ".kao-banner{" +
+  var cssClassicMini =
+    ".kao-banner.kao-banner--style-classic.kao-banner--mini{" +
       "position:relative;" +
       "font-variant-numeric:tabular-nums;" +
       "background:linear-gradient(180deg,#d32f2f 0%,#b71c1c 100%);" +
@@ -169,32 +378,33 @@
       "box-sizing:border-box;" +
     "}";
 
-  var cssMinimal =
-    ".kao-banner{" +
-    "position:relative;" +
-    "font-variant-numeric:tabular-nums;" +
-    "background:linear-gradient(180deg,#d32f2f 0%,#b71c1c 100%);" +
-    "border-bottom:2px solid #801313;" +
-    "color:#fff;" +
-    "font-family:'Arial Black',sans-serif;" +
-    "font-weight:900;" +
-    "text-transform:uppercase;" +
-    "letter-spacing:1px;" +
-    "font-size:0.75rem;" +
-    "text-align:center;" +
-    "text-shadow:" +
-    "0px 1px 0px #9e1a1a," +
-    "0px 2px 0px #8a1515," +
-    "0px 3px 5px rgba(0,0,0,0.4);" +
-    "padding:0.25rem 1.5rem;" +
-    "line-height:1.4;" +
-    "box-sizing:border-box;" +
+  var cssClassicMinimal =
+    ".kao-banner.kao-banner--style-classic.kao-banner--minimal{" +
+      "position:relative;" +
+      "font-variant-numeric:tabular-nums;" +
+      "background:linear-gradient(180deg,#d32f2f 0%,#b71c1c 100%);" +
+      "border-bottom:2px solid #801313;" +
+      "color:#fff;" +
+      "font-family:'Arial Black',sans-serif;" +
+      "font-weight:900;" +
+      "text-transform:uppercase;" +
+      "letter-spacing:1px;" +
+      "font-size:0.75rem;" +
+      "text-align:center;" +
+      "text-shadow:" +
+        "0px 1px 0px #9e1a1a," +
+        "0px 2px 0px #8a1515," +
+        "0px 3px 5px rgba(0,0,0,0.4);" +
+      "padding:0.25rem 1.5rem;" +
+      "line-height:1.4;" +
+      "box-sizing:border-box;" +
     "}";
 
-  var cssCommon =
-    ".kao-banner a{color:#fff;text-decoration:none;}" +
-    ".kao-banner a:hover{text-decoration:underline;}" +
-    ".kao-banner-close{" +
+  var cssClassicCommon =
+    ".kao-banner.kao-banner--style-classic a{color:#fff;text-decoration:none;}" +
+    ".kao-banner.kao-banner--style-classic a:hover{text-decoration:underline;}" +
+    ".kao-banner.kao-banner--style-classic .kao-banner-close,"+
+    ".kao-banner.kao-banner--style-classic .kao-banner__close{" +
       "position:absolute;" +
       "right:0.5rem;" +
       "top:50%;" +
@@ -209,21 +419,34 @@
       "line-height:1;" +
       "text-shadow:none;" +
     "}" +
-    ".kao-banner-close:hover{opacity:1;}";
+    ".kao-banner.kao-banner--style-classic .kao-banner-close:hover,"+
+    ".kao-banner.kao-banner--style-classic .kao-banner__close:hover{opacity:1;}";
 
-  var cssKaoPulse =
-    ".kao-banner:not(.no-animation) { animation:kao-pulse 2s infinite; }" +
+  var cssClassicPulse =
+    ".kao-banner.kao-banner--style-classic:not(.no-animation):not(.kao-banner--no-anim){" +
+      "animation:kao-pulse 2s infinite;" +
+    "}" +
     "@keyframes kao-pulse{" +
       "0%{box-shadow:0 0 0 0 rgba(211,47,47,0.7)}" +
       "70%{box-shadow:0 0 0 15px rgba(211,47,47,0)}" +
       "100%{box-shadow:0 0 0 0 rgba(211,47,47,0)}" +
+    "}" +
+    "@media(prefers-reduced-motion:reduce){" +
+      ".kao-banner.kao-banner--style-classic{animation:none!important;}" +
     "}";
 
-  var style = document.createElement("style");
-  style.textContent = (size === "mini" ? cssMini : size === "minimal" ? cssMinimal : cssNormal)
-    + (params.animation === "off" ? "" : cssKaoPulse)
-    + cssCommon;
-  document.head.appendChild(style);
+  var cssClassic =
+    cssClassicNormal +
+    cssClassicMini +
+    cssClassicMinimal +
+    cssClassicCommon +
+    cssClassicPulse;
+
+  // ── Inject single <style> ────────────────────────────────────────────
+  var styleEl = document.createElement("style");
+  styleEl.textContent =
+    cssTokens + cssBase + cssSizes + cssMedia + cssMotion + cssRtl + cssClassic;
+  document.head.appendChild(styleEl);
 
   // ── Check if previously dismissed (reappears after dismissDays) ─────
   if (showClose) {
@@ -237,39 +460,153 @@
     } catch (e) {}
   }
 
-  // ── Create banner DOM ─────────────────────────────────────────────────
+  // ── Build banner DOM ─────────────────────────────────────────────────
   var banner = document.createElement("div");
-  banner.className = params.animation === "off" ? "kao-banner no-animation" : "kao-banner";
+  var classes = ["kao-banner", "kao-banner--" + size];
+  if (styleMode === "classic") {
+    classes.push("kao-banner--style-classic");
+    if (noAnim) classes.push("no-animation");
+  } else {
+    classes.push("kao-banner--style-modern");
+    classes.push("kao-banner--theme-" + theme);
+    if (showClose) classes.push("kao-banner--has-close");
+  }
+  if (noAnim) classes.push("kao-banner--no-anim");
+  banner.className = classes.join(" ");
+  banner.setAttribute("role", "status");
+  banner.setAttribute("aria-live", "polite");
+  banner.setAttribute("aria-atomic", "false");
 
   var messageText = messages[locale] || messages.en;
+  var countdownSpan;
 
-  if (linkUrl) {
-    var link = document.createElement("a");
-    link.href = linkUrl;
-    link.target = "_blank";
-    link.rel = "noopener";
-    link.textContent = messageText;
-    banner.appendChild(link);
+  if (styleMode === "classic") {
+    // ── Classic DOM (preserve original structure 1:1) ────────────────
+    if (linkUrl) {
+      var classicLink = document.createElement("a");
+      classicLink.href = linkUrl;
+      classicLink.target = "_blank";
+      classicLink.rel = "noopener";
+      classicLink.textContent = messageText;
+      banner.appendChild(classicLink);
+    } else {
+      banner.appendChild(document.createTextNode(messageText));
+    }
+
+    if (size === "minimal") {
+      banner.appendChild(document.createTextNode(" "));
+    } else {
+      banner.appendChild(document.createElement("br"));
+    }
+
+    countdownSpan = document.createElement("span");
+    countdownSpan.textContent = " ";
+    banner.appendChild(countdownSpan);
   } else {
-    banner.appendChild(document.createTextNode(messageText));
+    // ── Modern DOM ────────────────────────────────────────────────────
+    var inner = document.createElement("div");
+    inner.className = "kao-banner__inner";
+
+    // Warning icon (hidden in minimal). ISO-7010-style filled triangle
+    // with a high-contrast exclamation drawn on top — much crisper at
+    // 18–22 px than a hollow outline.
+    if (size !== "minimal") {
+      var SVG_NS = "http://www.w3.org/2000/svg";
+      var svg = document.createElementNS(SVG_NS, "svg");
+      svg.setAttribute("class", "kao-banner__icon");
+      svg.setAttribute("viewBox", "0 0 24 24");
+      svg.setAttribute("aria-hidden", "true");
+      svg.setAttribute("focusable", "false");
+
+      // Filled triangle with rounded corners (color = currentColor = --kao-accent)
+      var tri = document.createElementNS(SVG_NS, "path");
+      tri.setAttribute("d", "M12 2.5L1 21.5h22L12 2.5z");
+      tri.setAttribute("fill", "currentColor");
+      tri.setAttribute("stroke", "currentColor");
+      tri.setAttribute("stroke-width", "1.2");
+      tri.setAttribute("stroke-linejoin", "round");
+      svg.appendChild(tri);
+
+      // Exclamation mark (rect + dot) in fixed dark color for contrast
+      var mark = document.createElementNS(SVG_NS, "path");
+      mark.setAttribute("class", "kao-banner__icon-mark");
+      mark.setAttribute("d", "M11 9h2v6h-2zm0 8h2v2h-2z");
+      svg.appendChild(mark);
+
+      inner.appendChild(svg);
+    }
+
+    // Text container (brand + verify)
+    var textEl = document.createElement("p");
+    textEl.className = "kao-banner__text";
+
+    if (size !== "minimal") {
+      var brand = document.createElement("span");
+      brand.className = "kao-banner__brand";
+      brand.textContent = "Keep Android Open";
+      textEl.appendChild(brand);
+    }
+
+    // For minimal mode with linkUrl, the verify text itself becomes a link
+    // (since CTA is hidden in minimal). For other sizes, verify is plain text
+    // and the CTA carries the link.
+    var verify;
+    if (size === "minimal" && linkUrl) {
+      verify = document.createElement("a");
+      verify.href = linkUrl;
+      verify.target = "_blank";
+      verify.rel = "noopener";
+    } else {
+      verify = document.createElement("span");
+    }
+    verify.className = "kao-banner__verify";
+    verify.textContent = messageText;
+    textEl.appendChild(verify);
+
+    inner.appendChild(textEl);
+
+    // Countdown pill (per-tick, aria-hidden)
+    countdownSpan = document.createElement("span");
+    countdownSpan.className = "kao-banner__count";
+    countdownSpan.setAttribute("aria-hidden", "true");
+    countdownSpan.textContent = " ";
+    inner.appendChild(countdownSpan);
+
+    // CTA (normal + mini, when linkUrl present)
+    if (size !== "minimal" && linkUrl) {
+      var cta = document.createElement("a");
+      cta.className = "kao-banner__cta";
+      cta.href = linkUrl;
+      cta.target = "_blank";
+      cta.rel = "noopener";
+      cta.setAttribute("aria-label", "Read why this matters");
+
+      var ctaLabel = document.createElement("span");
+      ctaLabel.className = "kao-banner__cta__label";
+      ctaLabel.textContent = "Read why";
+      cta.appendChild(ctaLabel);
+
+      var ctaArrow = document.createElement("span");
+      ctaArrow.className = "kao-banner__cta__arrow";
+      ctaArrow.setAttribute("aria-hidden", "true");
+      ctaArrow.textContent = "→";
+      cta.appendChild(ctaArrow);
+
+      inner.appendChild(cta);
+    }
+
+    banner.appendChild(inner);
   }
 
-  if (params.size === "minimal") {
-    banner.appendChild(document.createTextNode("\u00A0"));
-  } else {
-    banner.appendChild(document.createElement("br"));
-  }
-
-  var countdownSpan = document.createElement("span");
-  countdownSpan.textContent = "\u00A0";
-  banner.appendChild(countdownSpan);
-
-  // Close button
+  // ── Close button (both modes) ────────────────────────────────────────
   if (showClose) {
     var closeBtn = document.createElement("button");
-    closeBtn.className = "kao-banner-close";
+    closeBtn.type = "button";
+    // Both class names: legacy `kao-banner-close` for back-compat with any
+    // embedder CSS overrides, plus the new `kao-banner__close` BEM name.
+    closeBtn.className = "kao-banner-close kao-banner__close";
     closeBtn.setAttribute("aria-label", "Close");
-    closeBtn.textContent = "\u2715";
+    closeBtn.textContent = "✕";
     closeBtn.addEventListener("click", function () {
       banner.style.display = "none";
       try { localStorage.setItem(storageKey, String(Date.now())); } catch (e) {}
@@ -277,7 +614,17 @@
     banner.appendChild(closeBtn);
   }
 
-  // Insert into target element (by id) or prepend to <body>
+  // ── Visually-hidden a11y status (modern only, daily updates) ────────
+  var a11yStatus = null;
+  if (styleMode === "modern") {
+    a11yStatus = document.createElement("span");
+    a11yStatus.className = "kao-banner__a11y-status";
+    a11yStatus.setAttribute("aria-live", "polite");
+    a11yStatus.setAttribute("aria-atomic", "true");
+    banner.appendChild(a11yStatus);
+  }
+
+  // ── Insert into DOM (target id, or prepend to body) ─────────────────
   var targetId = params.id;
   if (targetId) {
     var target = document.getElementById(targetId);
@@ -290,7 +637,7 @@
     document.body.insertBefore(banner, document.body.firstChild);
   }
 
-  // ── Countdown logic ───────────────────────────────────────────────────
+  // ── Countdown logic (unchanged formatter, retargeted span) ──────────
   var countDownDate = new Date("Sep 1, 2026 00:00:00").getTime();
 
   var unitFormatters = {
@@ -300,6 +647,10 @@
     second: new Intl.NumberFormat(locale, { style: "unit", unit: "second", unitDisplay: "narrow" })
   };
 
+  var dayFormatter = new Intl.NumberFormat(locale, {
+    style: "unit", unit: "day", unitDisplay: "long"
+  });
+
   function formatUnit(value, unit) {
     return unitFormatters[unit].format(value);
   }
@@ -307,6 +658,7 @@
   var remaining = new Array(7);
   var separator = " ";
   var timer = null;
+  var lastA11yDay = -1;
 
   function updateBanner() {
     var now = new Date().getTime();
@@ -338,6 +690,12 @@
     remaining[6] = formatUnit(seconds, "second");
 
     countdownSpan.textContent = remaining.join("");
+
+    // Update screen-reader status only when the day count changes.
+    if (a11yStatus && days !== lastA11yDay) {
+      lastA11yDay = days;
+      a11yStatus.textContent = days > 0 ? dayFormatter.format(days) : "";
+    }
 
     if (distance < 0) {
       clearInterval(timer);


### PR DESCRIPTION
## TL;DR
This PR refreshes `public/banner.js` with a slimmer, more embeddable warning bar while preserving every existing query parameter, language string, and embed contract. Embedders who prefer the current look can pin to it with one new opt-in parameter: `?style=classic`.

## Why
- **Visual weight on host sites**: the current bold all-caps red banner can dominate supporter pages and discourage embedding above the fold.
- **No theme awareness**: the banner ignores `prefers-color-scheme`, which clashes with the growing number of dark-themed supporter sites.
- **Accessibility gaps**: no `prefers-reduced-motion` fallback and no RTL flow handling for Arabic / Hebrew / Persian embedders.

## What changes
- Slim amber warning bar replaces the all-caps red block, with a warning-triangle SVG icon for instant recognition (filled, ISO-7010-style for crisp rendering at 18–22 px).
- Countdown is rendered in a monospace pill so digits stop reflowing on each tick.
- A subtle **Read why** CTA link sits next to the message for clearer affordance.
- Adds dark-mode tokens (light / dark / auto), `prefers-reduced-motion` fallback, and RTL mirroring (arrow flips, `inset-inline-end` everywhere).
- Visually-hidden `aria-live="polite"` status node updates **once per day** (not per tick) so screen readers aren't flooded by the countdown.

## What stays the same
- Every existing query param works identically: `lang`, `id`, `size`, `link`, `hidebutton`, `animation`.
- All 30+ language strings are unchanged — no translator action required (verified byte-equal).
- Same `<script src="…/banner.js">` embed pattern — no markup changes on supporter sites.
- Same `localStorage` dismiss key (`kao-banner-hidden`) and 30-day re-show window.
- Same DOM injection point (target `id` or `prepend(<body>)`).
- Same single-file IIFE / ES5 floor — `var`, string concatenation, no template literals, no arrow functions. `Intl.NumberFormat({ style: "unit" })` remains the highest floor.

## New optional params
| Param | Values | Default | Purpose |
|---|---|---|---|
| `theme` | `auto` \| `light` \| `dark` | `auto` | Override system theme detection |
| `style` | `modern` \| `classic` | `modern` | `classic` renders the pre-PR design 1:1 |

## Compatibility & rollout
- `style=classic` preserves the original look pixel-for-pixel — single-param opt-out for embedders. The classic block is namespaced under `.kao-banner.kao-banner--style-classic` and reuses the original CSS verbatim, so the red Arial-Black aesthetic is byte-faithful (verified visually side-by-side).
- Modern selectors are namespaced under `.kao-banner.kao-banner--style-modern` so they cannot leak into classic.
- Close-button keeps both the legacy `.kao-banner-close` and the new `.kao-banner__close` class hooks for any embedder CSS overrides in the wild.
- Deployment is a single-file replacement of `public/banner.js`; no new assets, no build step, no breaking change to the embed contract.

## Try it
```html
<!-- Default (modern, auto theme) -->
<script src="https://keepandroidopen.org/banner.js?lang=en"></script>

<!-- Force dark theme -->
<script src="https://keepandroidopen.org/banner.js?lang=en&theme=dark"></script>

<!-- Force light theme -->
<script src="https://keepandroidopen.org/banner.js?lang=en&theme=light"></script>

<!-- Original design preserved 1:1 -->
<script src="https://keepandroidopen.org/banner.js?lang=en&style=classic"></script>
```

## Verified locally
- All three sizes (`normal` / `mini` / `minimal`) × both styles (`modern` / `classic`) × both themes (`light` / `dark`) × `theme=auto` under both light and dark OS settings.
- All 30+ locales render their localized strings (German, Russian, Thai, Japanese, Chinese, Korean, etc.).
- Arabic with `dir="rtl"`: arrow flips, dismiss button mirrors to the start side.
- `animation=off` disables the icon pulse (modern) and the box-shadow pulse (classic).
- `hidebutton=off` removes the close button.
- `link=none` removes the CTA link in modern; preserves text-only behavior in classic.
- Close → reload re-suppresses; advancing the timestamp 31 days re-shows.
- Tested under `prefers-reduced-motion: reduce` — animations replaced with static states.
- No console errors / warnings across all variants.

## Open questions
1. Should `style=classic` be the default for the first ~2 weeks (soft launch) before flipping the default to `modern`? Happy to flip the ternary.
2. Should `position=top|inline` ship in this PR, or land as a follow-up? It's not implemented here — kept the PR small.

## Closing
Fully open to your judgment here — the campaign's voice and visual urgency are yours to set, and we'd be glad to tune tokens (color, height, copy weight), drop sections, or pull the PR back entirely if the current design is serving the cause better. Thank you for keeping this banner maintained and easy to embed; happy to iterate on whatever direction is most useful.
