### PR TITLE
CSS: Prevent .hero-lede bottom cut-off, improve .ticker-card looks

### DIFF
--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -206,6 +206,7 @@
       line-height: 1.15;
       max-width: 700px;
       margin: 0 auto 1.5rem;
+      padding-bottom: 0.2em;
       letter-spacing: -0.02em;
       background: linear-gradient(135deg, #d32f2f 0%, #ff6659 100%);
       -webkit-background-clip: text;
@@ -744,14 +745,25 @@
     }
 
     .ticker-card p {
+      position: relative;
       margin: 0 0 0.5rem;
       font-style: italic;
       font-weight: 500;
-      line-height: 1.4;
+      line-height: 1.25;
       display: -webkit-box;
       -webkit-line-clamp: 6;
       -webkit-box-orient: vertical;
       overflow: hidden;
+    }
+
+    .ticker-card p::after {
+        content: "";
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 2em;
+        height: 2em;
+        background: linear-gradient(0deg, hsl(var(--tc-h), var(--tc-s), 96%) 25%, rgba(255, 255, 255, 0));
     }
 
     .ticker-card cite {


### PR DESCRIPTION

<img width="689" height="154" alt="image" src="https://github.com/user-attachments/assets/91f4e801-6f5c-4f2e-96db-6b22f53d8a54" />

to

<img width="672" height="161" alt="image" src="https://github.com/user-attachments/assets/b6121285-bb62-45a3-b8da-c9d2fcd1525a" />

and

<img width="778" height="213" alt="image" src="https://github.com/user-attachments/assets/968e3721-7354-43e3-96ea-33eb7f0b9a24" />

to

<img width="636" height="214" alt="image" src="https://github.com/user-attachments/assets/0b1c5985-f5f1-42ef-97b4-cf7107b5a363" />


Still not perfect, but can be tweaked.