### PR TITLE
Update countdown deadline to Sep 30 2026

### DIFF
--- a/public/banner.js
+++ b/public/banner.js
@@ -291,7 +291,7 @@
   }
 
   // ── Countdown logic ───────────────────────────────────────────────────
-  var countDownDate = new Date("Sep 1, 2026 00:00:00").getTime();
+  var countDownDate = new Date("Sep 30, 2026 00:00:00").getTime();
 
   var unitFormatters = {
     day: new Intl.NumberFormat(locale, { style: "unit", unit: "day", unitDisplay: "narrow" }),

--- a/src/layouts/Landing.astro
+++ b/src/layouts/Landing.astro
@@ -56,7 +56,7 @@ const shuffledSigs = shuffle(signatures as any[]);
 const sigCountryCount = new Set(signatures.map((s: any) => s.region).filter(Boolean)).size;
 
 // countdown
-const deadline = new Date('2026-09-01T00:00:00Z');
+const deadline = new Date('2026-09-30T00:00:00Z');
 const now = new Date();
 const daysLeft = Math.max(0, Math.ceil((deadline.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)));
 


### PR DESCRIPTION
The new post at https://android-developers.googleblog.com/2026/06/android-developer-verification.html specifies September 30, 2026 as the date the lockdown starts. Previously they had just said "September", so out countdown banner had assumed September 1st.

This will have the effect of setting back the countdown clock by 30 days.